### PR TITLE
fix: Mejorar la transicion entre videos para evitar cambios bruscos

### DIFF
--- a/src/routes/home/home.jsx
+++ b/src/routes/home/home.jsx
@@ -27,9 +27,10 @@ export default function Home() {
 
 
     useEffect(() => {
-
-
+        const video_trailer_home = document.querySelector("#video-trailer_home")
+        
         const interval = setInterval(() => {
+            video_trailer_home.style.opacity = 1
             //cada 3 segundos se cambiara de video
             setListaPlayIndice(prevState => {
 
@@ -40,26 +41,15 @@ export default function Home() {
                     //  console.log(listaVideo[prevState])
                     return 0
                 }
-
-
-
                 return prevState + 1
             })
+            
         }, 6000)
-
-
-
-        const video_trailer_home = document.querySelector("#video-trailer_home")
-
-
-        video_trailer_home.style.opacity = "0"
-
-        const time = setTimeout(() => {
-            video_trailer_home.style.opacity = "1"
-
-        }, 900)
-
-
+        const time = setTimeout(()=>{
+            video_trailer_home.style.opacity = 0
+        }, 5500)
+        //video_trailer_home.classList.add('fadeOut')   
+        
 
         if (video_trailer_home) {
 
@@ -90,7 +80,7 @@ export default function Home() {
 
 
 
-    }, [, listaPlayIndice])
+    }, [listaPlayIndice])
 
 
     useEffect(() => {
@@ -112,7 +102,7 @@ export default function Home() {
             <div className="ventanaContent_home">
                 <div className="videoContainer_home">
 
-                    <video id="video-trailer_home" muted autoplay playsinline>
+                    <video id="video-trailer_home" muted autoPlay playsInline>
                         <source src={listaVideo[listaPlayIndice]}></source>
                     </video>
                     <audio id="audio">


### PR DESCRIPTION
Esta PR soluciona el problema de transición entre videos, evitando cambios bruscos durante el cambio entre diferentes videos 👻👻
**Explicacion**
 
📄 Se implementó un setInterval que inicia junto con un setTimeout.
📄 El setTimeout se configura para que se ejecute 0.5 segundos antes de cambiar de video, iniciando un cambio de opacidad en la etiqueta HTML del video.
📄 La transición de opacidad está definida en los estilos CSS, utlizando exactamente la diferencia entre 5.5s y 6s

🗿